### PR TITLE
More example charts

### DIFF
--- a/test/area.vl.json
+++ b/test/area.vl.json
@@ -1,0 +1,29 @@
+{
+  "config": {"view": {"width": 400, "height": 300}},
+  "data": {
+    "url": "https://vega.github.io/vega-datasets/data/iowa-electricity.csv",
+    "format": {"type": "csv"}
+  },
+  "title": "Iowa's renewable energy boom",
+  "mark": "area",
+  "encoding": {
+    "color": {
+      "type": "nominal",
+      "field": "source",
+      "legend": {"title": "Electricity source"}
+    },
+    "x": {
+      "type": "temporal",
+      "axis": {"title": "Year"},
+      "field": "year",
+      "timeUnit": "year"
+    },
+    "y": {
+      "type": "quantitative",
+      "axis": {"format": ".0%", "title": "Share of net generation"},
+      "field": "net_generation",
+      "stack": "normalize"
+    }
+  },
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.6.0.json"
+}

--- a/test/heatmap.vl.json
+++ b/test/heatmap.vl.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+  "data": {
+      "url": "https://vega.github.io/vega-datasets/data/seattle-temps.csv"
+  },
+  "title": "2010 Daily Max Temperature in Seattle",
+  "config": {
+      "view": {
+          "strokeWidth": 0
+      },
+      "scale": {
+          "rangeStep": 13
+      },
+      "axis": {
+          "domain": false
+      }
+  },
+  "mark": "rect",
+  "encoding": {
+      "x": {
+          "field": "date",
+          "timeUnit": "date",
+          "type": "ordinal",
+          "title": "Day",
+          "axis": {
+              "labelAngle": 0,
+              "format": "%e"
+          }
+      },
+      "y": {
+          "field": "date",
+          "timeUnit": "month",
+          "type": "ordinal",
+          "title": "Month"
+      },
+      "color": {
+          "field": "temp",
+          "aggregate": "max",
+          "type": "quantitative",
+          "legend": {
+              "title": null
+          }
+      }
+  }
+}

--- a/test/index.html
+++ b/test/index.html
@@ -50,7 +50,10 @@ var files = [
   'bars.vg.json',
   'lines.vg.json',
   'scatter.vg.json',
-  'stacked.vl.json'
+  'stacked.vl.json',
+  'area.vl.json',
+  'heatmap.vl.json',
+  'ramp.vl.json'
 ];
 var specs = [];
 

--- a/test/ramp.vl.json
+++ b/test/ramp.vl.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+  "width": 500,
+  "height": 300,
+  "title": "Unemployment rate per county",
+  "data": {
+    "url": "https://vega.github.io/vega-datasets/data/us-10m.json",
+    "format": {
+      "type": "topojson",
+      "feature": "counties"
+    }
+  },
+  "transform": [{
+    "lookup": "id",
+    "from": {
+      "data": {
+        "url": "https://vega.github.io/vega-datasets/data/unemployment.tsv"
+      },
+      "key": "id",
+      "fields": ["rate"]
+    }
+  }],
+  "projection": {
+    "type": "albersUsa"
+  },
+  "mark": "geoshape",
+  "encoding": {
+    "color": {
+      "field": "rate",
+      "type": "quantitative"
+    }
+  }
+}


### PR DESCRIPTION
Adding a few more example charts has helped me as I develop our LA Times theme for Vega and Altair. 

![screenshot from 2019-02-10 11-50-31](https://user-images.githubusercontent.com/9993/52538676-5174db80-2d2a-11e9-9181-8837cb88195c.png)
