### PR TITLE
Fix for SVG rendering dropdown in examples gallery

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -150,7 +150,7 @@
           el.setAttribute("class", "view");
           container.appendChild(el);
           vegaEmbed(el, spec, {
-            render: renderType,
+            renderer: renderType,
             config: theme,
             defaultStyle: true
           });


### PR DESCRIPTION
Changing key in vegaEmbed to `renderer` to enable SVG rendering.