### PR TITLE
Add Urban Institute theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ vega.themes.<b>latimes</b>
 
 Chart theme modeled after the Los Angeles Times. [Try it here](https://vega.github.io/vega-themes/?theme=latimes).
 
+<a name="urbaninstitute" href="#urbaninstitute">#</a>
+vega.themes.<b>urbaninstitute</b>
+[<>](https://github.com/vega/vega-themes/blob/master/src/theme-urbaninstitute.js "Source")
+
+Chart theme modeled after the Urban Institute. [Try it here](https://vega.github.io/vega-themes/?theme=urbaninstitute).
+
 ## Instructions for Developers
 
 To view and test different themes, follow these steps:

--- a/examples/index.html
+++ b/examples/index.html
@@ -59,6 +59,7 @@
         <option value="dark">dark</option>
         <option value="fivethirtyeight">fivethirtyeight</option>
         <option value="latimes">latimes</option>
+        <option value="urbaninstitute">urbaninstitute</option>
       </select>
       &nbsp; Renderer:
       <select id="render">

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export {default as ggplot2} from './theme-ggplot2';
 export {default as latimes} from './theme-latimes';
 export {default as quartz} from './theme-quartz';
 export {default as vox} from './theme-vox';
+export {default as urbaninstitute} from './theme-urbaninstitute';
 export {version};

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -11,13 +11,13 @@ const titleFontSize = 18;
 
 const colorSchemes = {
   'main-colors': ['#1696d2', '#d2d2d2', '#000000', '#fdbf11', '#ec008b', '#55b748', '#5c5859', '#db2b27'],
-  'shades-blue': ['#CFE8F3','#A2D4EC','#73BFE2','#46ABDB','#1696D2','#12719E','#0A4C6A','#062635'],
-  'shades-gray': ['#F5F5F5','#ECECEC','#E3E3E3','#DCDBDB','#D2D2D2','#9D9D9D','#696969','#353535'],
-  'shades-yellow': ['#FFF2CF','#FCE39E','#FDD870','#FCCB41','#FDBF11','#E88E2D','#CA5800','#843215'],
-  'shades-magenta': ['#F5CBDF','#EB99C2','#E46AA7','#E54096','#EC008B','#AF1F6B','#761548','#351123'],
-  'shades-green': ['#DCEDD9','#BCDEB4','#98CF90','#78C26D','#55B748','#408941','#2C5C2D','#1A2E19'],
-  'shades-black': ['#D5D5D4','#ADABAC','#848081','#5C5859','#332D2F','#262223','#1A1717','#0E0C0D'],
-  'shades-red': ['#F8D5D4','#F1AAA9','#E9807D','#E25552','#DB2B27','#A4201D','#6E1614','#370B0A'],
+  'shades-blue': ['#CFE8F3', '#A2D4EC', '#73BFE2', '#46ABDB', '#1696D2', '#12719E', '#0A4C6A', '#062635'],
+  'shades-gray': ['#F5F5F5', '#ECECEC', '#E3E3E3', '#DCDBDB', '#D2D2D2', '#9D9D9D', '#696969', '#353535'],
+  'shades-yellow': ['#FFF2CF', '#FCE39E', '#FDD870', '#FCCB41', '#FDBF11', '#E88E2D', '#CA5800', '#843215'],
+  'shades-magenta': ['#F5CBDF', '#EB99C2', '#E46AA7', '#E54096', '#EC008B', '#AF1F6B', '#761548', '#351123'],
+  'shades-green': ['#DCEDD9', '#BCDEB4', '#98CF90', '#78C26D', '#55B748', '#408941', '#2C5C2D', '#1A2E19'],
+  'shades-black': ['#D5D5D4', '#ADABAC', '#848081', '#5C5859', '#332D2F', '#262223', '#1A1717', '#0E0C0D'],
+  'shades-red': ['#F8D5D4', '#F1AAA9', '#E9807D', '#E25552', '#DB2B27', '#A4201D', '#6E1614', '#370B0A'],
   'one-group': ['#1696d2', '#000000'],
   'two-groups-cat-1': ['#1696d2', '#000000'],
   'two-groups-cat-2': ['#1696d2', '#fdbf11'],
@@ -43,8 +43,8 @@ const urbanInstituteTheme: Config = {
   title: {
     anchor: 'start',
     fontSize: titleFontSize,
-    font: font,
-},
+    font: font
+  },
 
 axisX: {
    domain: true,

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -46,107 +46,107 @@ const urbanInstituteTheme: Config = {
     font: font
   },
 
-axisX: {
-   domain: true,
-   domainColor: axisColor,
-   domainWidth: 1,
-   grid: false,
-   labelFontSize: 12,
-   labelFont: labelFont,
-   labelAngle: 0,
-   tickColor: axisColor,
-   tickSize: 5,
-   titleFontSize: 12,
-   titlePadding: 10,
-   titleFont: font,
-},
+  axisX: {
+    domain: true,
+    domainColor: axisColor,
+    domainWidth: 1,
+    grid: false,
+    labelFontSize: 12,
+    labelFont: labelFont,
+    labelAngle: 0,
+    tickColor: axisColor,
+    tickSize: 5,
+    titleFontSize: 12,
+    titlePadding: 10,
+    titleFont: font,
+  },
 
-axisY: {
-   domain: false,
-   domainWidth: 1,
-   grid: true,
-   gridColor: gridColor,
-   gridWidth: 1,
-   labelFontSize: 12,
-   labelFont: labelFont,
-   labelPadding: 8,
-   ticks: false,
-   titleFontSize: 12,
-   titlePadding: 10,
-   titleFont: font,
-   titleAngle: 0,
-   titleY: -10,
-   titleX: 18,
-},
+ axisY: {
+    domain: false,
+    domainWidth: 1,
+    grid: true,
+    gridColor: gridColor,
+    gridWidth: 1,
+    labelFontSize: 12,
+    labelFont: labelFont,
+    labelPadding: 8,
+    ticks: false,
+    titleFontSize: 12,
+    titlePadding: 10,
+    titleFont: font,
+    titleAngle: 0,
+    titleY: -10,
+    titleX: 18,
+  },
 
-legend: {
-   labelFontSize: 12,
-   labelFont: labelFont,
-   symbolSize: 100,
-   titleFontSize: 12,
-   titlePadding: 10,
-   titleFont: font,
-   orient: 'right',
-   offset: 10,
-},
+ legend: {
+    labelFontSize: 12,
+    labelFont: labelFont,
+    symbolSize: 100,
+    titleFontSize: 12,
+    titlePadding: 10,
+    titleFont: font,
+    orient: 'right',
+    offset: 10,
+  },
 
-view: {
-   stroke: 'transparent',
-},
+ view: {
+    stroke: 'transparent',
+  },
 
-range: {
-   category: colorSchemes['six-groups-cat-1'],
-   diverging: colorSchemes['diverging'],
-   heatmap: colorSchemes['diverging'],
-   ordinal: colorSchemes['six-groups-seq'],
-   ramp: colorSchemes['shades-blue'],
-},
+ range: {
+    category: colorSchemes['six-groups-cat-1'],
+    diverging: colorSchemes['diverging'],
+    heatmap: colorSchemes['diverging'],
+    ordinal: colorSchemes['six-groups-seq'],
+    ramp: colorSchemes['shades-blue'],
+  },
 
-area: {
-   fill: markColor,
-},
+ area: {
+    fill: markColor,
+  },
 
-rect: {
-   fill: markColor,
-},
+ rect: {
+    fill: markColor,
+  },
 
-line: {
-   color: markColor,
-   stroke: markColor,
-   strokeWidth: 5,
-},
+ line: {
+    color: markColor,
+    stroke: markColor,
+    strokeWidth: 5,
+  },
 
-trail: {
-   color: markColor,
-   stroke: markColor,
-   strokeWidth: 0,
-   size: 1,
-},
+ trail: {
+    color: markColor,
+    stroke: markColor,
+    strokeWidth: 0,
+    size: 1,
+  },
 
-path: {
-   stroke: markColor,
-   strokeWidth: 0.5,
-},
+ path: {
+    stroke: markColor,
+    strokeWidth: 0.5,
+  },
 
-point: {
-   filled: true,
-},
+ point: {
+    filled: true,
+  },
 
-text: {
-   font: sourceFont,
-   color: markColor,
-   fontSize: 11,
-   align: 'center',
-   fontWeight: 400,
-   size: 11,
-}, 
+ text: {
+    font: sourceFont,
+    color: markColor,
+    fontSize: 11,
+    align: 'center',
+    fontWeight: 400,
+    size: 11,
+  }, 
 
-style: {
-bar: {
+ style: {
+ bar: {
     fill: markColor,
     stroke: false,
    }
-},
+  },
 
 arc: {fill: markColor},
 shape: {stroke: markColor},

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -39,12 +39,13 @@ const colorSchemes = {
 
 const urbanInstituteTheme: Config = {
   background: backgroundColor,
+
   title: {
     anchor: "start",
     fontSize: titleFontSize,
     font: font,
-    fontColor: "#000000"
 },
+
 axisX: {
    domain: true,
    domainColor: axisColor,
@@ -58,8 +59,9 @@ axisX: {
    titleFontSize: 12,
    titlePadding: 10,
    titleFont: font,
-   title: "",
+   //title: " ",
 },
+
 axisY: {
    domain: false,
    domainWidth: 1,
@@ -77,6 +79,7 @@ axisY: {
    titleY: -10,
    titleX: 18,
 },
+
 legend: {
    labelFontSize: 12,
    labelFont: labelFont,
@@ -85,44 +88,53 @@ legend: {
    titleFontSize: 12,
    titlePadding: 10,
    titleFont: font,
-   title: "",
+   //title: " ",
    orient: "right",
    offset: 10,
 },
+
 view: {
    stroke: "transparent",
 },
+
 range: {
    category: colorSchemes['six-groups-cat-1'],
    diverging: colorSchemes['diverging'],
    heatmap: colorSchemes['diverging'],
    ordinal: colorSchemes['six-groups-seq'],
-   ramp: colorSchemes['shades-blue']
+   ramp: colorSchemes['shades-blue'],
 },
+
 area: {
    fill: markColor,
 },
+
 rect: {
    fill: markColor,
 },
+
 line: {
    color: markColor,
    stroke: markColor,
-   strokewidth: 5,
+   strokeWidth: 5,
 },
+
 trail: {
    color: markColor,
    stroke: markColor,
    strokeWidth: 0,
    size: 1,
 },
+
 path: {
    stroke: markColor,
    strokeWidth: 0.5,
 },
+
 point: {
    filled: true,
 },
+
 text: {
    font: sourceFont,
    color: markColor,
@@ -131,17 +143,17 @@ text: {
    fontWeight: 400,
    size: 11,
 }, 
+
+style: {
 bar: {
-    // "size": 40,
-    // "binSpacing": 15,
-    // "continuousBandSize": 30,
-    // "discreteBandSize": 30,
     fill: markColor,
     stroke: false,
+   }
 },
+
 arc: {fill: markColor},
 shape: {stroke: markColor},
-symbol: {fill: markColor, size: 30},
+symbol: {fill: markColor, size: 30}
 };
 
 export default urbanInstituteTheme;

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -142,9 +142,9 @@ const urbanInstituteTheme: Config = {
   },
 
   style: {
-   bar: {
-     fill: markColor,
-     stroke: false,
+    bar: {
+      fill: markColor,
+      stroke: false,
     }
   },
 

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -144,7 +144,7 @@ const urbanInstituteTheme: Config = {
   style: {
     bar: {
       fill: markColor,
-      stroke: false,
+      stroke: false
     }
   },
 

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -1,0 +1,147 @@
+import {Config} from './config';
+
+const markColor = "#1696d2";
+const axisColor = "#000000";
+const backgroundColor = "#FFFFFF";
+const font = "Lato";
+const labelFont = "Lato";
+const sourceFont = "Lato";
+const gridColor = "#DEDDDD";
+const titleFontSize = 18;
+
+const colorSchemes = {
+  'main-colors': ['#1696d2', '#d2d2d2', '#000000', '#fdbf11', '#ec008b', '#55b748', '#5c5859', '#db2b27'],
+  'shades-blue': ["#CFE8F3","#A2D4EC","#73BFE2","#46ABDB","#1696D2","#12719E","#0A4C6A","#062635"],
+  'shades-gray': ["#F5F5F5","#ECECEC","#E3E3E3","#DCDBDB","#D2D2D2","#9D9D9D","#696969","#353535"],
+  'shades-yellow': ["#FFF2CF","#FCE39E","#FDD870","#FCCB41","#FDBF11","#E88E2D","#CA5800","#843215"],
+  'shades-magenta': ["#F5CBDF","#EB99C2","#E46AA7","#E54096","#EC008B","#AF1F6B","#761548","#351123"],
+  'shades-green': ["#DCEDD9","#BCDEB4","#98CF90","#78C26D","#55B748","#408941","#2C5C2D","#1A2E19"],
+  'shades-black': ["#D5D5D4","#ADABAC","#848081","#5C5859","#332D2F","#262223","#1A1717","#0E0C0D"],
+  'shades-red': ["#F8D5D4","#F1AAA9","#E9807D","#E25552","#DB2B27","#A4201D","#6E1614","#370B0A"],
+  'one-group': ['#1696d2', '#000000'],
+  'two-groups-cat-1': ['#1696d2', '#000000'],
+  'two-groups-cat-2': ['#1696d2', '#fdbf11'],
+  'two-groups-cat-3': ['#1696d2', '#db2b27'],
+  'two-groups-seq': ['#a2d4ec', '#1696d2'],
+  'three-groups-cat': ['#1696d2', '#fdbf11', '#000000'],
+  'three-groups-seq': ['#a2d4ec', '#1696d2', '#0a4c6a'],
+  'four-groups-cat-1': ['#000000', '#d2d2d2', '#fdbf11', '#1696d2'],
+  'four-groups-cat-2': ['#1696d2', '#ec0008b', '#fdbf11', '#5c5859'],
+  'four-groups-seq': ['#cfe8f3', '#73bf42', '#1696d2', '#0a4c6a'],
+  'five-groups-cat-1': ['#1696d2', '#fdbf11', '#d2d2d2', '#ec008b', '#000000'],
+  'five-groups-cat-2': ['#1696d2', '#0a4c6a', '#d2d2d2', '#fdbf11', '#332d2f'],
+  'five-groups-seq': ['#cfe8f3', '#73bf42', '#1696d2', '#0a4c6a', '#000000'],
+  'six-groups-cat-1': ['#1696d2', '#ec008b', '#fdbf11', '#000000', '#d2d2d2', '#55b748'],
+  'six-groups-cat-2': ['#1696d2', '#d2d2d2', '#ec008b', '#fdbf11', '#332d2f', '#0a4c6a'],
+  'six-groups-seq': ['#cfe8f3', '#a2d4ec', '#73bfe2', '#46abdb', '#1696d2', '#12719e'],
+  'diverging': ['#ca5800', '#fdbf11', '#fdd870', '#fff2cf', '#cfe8f3', '#73bfe2', '#1696d2', '#0a4c6a']
+};
+
+const urbanInstituteTheme: Config = {
+  background: backgroundColor,
+  title: {
+    anchor: "start",
+    fontSize: titleFontSize,
+    font: font,
+    fontColor: "#000000"
+},
+axisX: {
+   domain: true,
+   domainColor: axisColor,
+   domainWidth: 1,
+   grid: false,
+   labelFontSize: 12,
+   labelFont: labelFont,
+   labelAngle: 0,
+   tickColor: axisColor,
+   tickSize: 5,
+   titleFontSize: 12,
+   titlePadding: 10,
+   titleFont: font,
+   title: "",
+},
+axisY: {
+   domain: false,
+   domainWidth: 1,
+   grid: true,
+   gridColor: gridColor,
+   gridWidth: 1,
+   labelFontSize: 12,
+   labelFont: labelFont,
+   labelPadding: 8,
+   ticks: false,
+   titleFontSize: 12,
+   titlePadding: 10,
+   titleFont: font,
+   titleAngle: 0,
+   titleY: -10,
+   titleX: 18,
+},
+legend: {
+   labelFontSize: 12,
+   labelFont: labelFont,
+   symbolSize: 100,
+   // "symbolType": "square",
+   titleFontSize: 12,
+   titlePadding: 10,
+   titleFont: font,
+   title: "",
+   orient: "right",
+   offset: 10,
+},
+view: {
+   stroke: "transparent",
+},
+range: {
+   category: colorSchemes['six-groups-cat-1'],
+   diverging: colorSchemes['diverging'],
+   heatmap: colorSchemes['diverging'],
+   ordinal: colorSchemes['six-groups-seq'],
+   ramp: colorSchemes['shades-blue']
+},
+area: {
+   fill: markColor,
+},
+rect: {
+   fill: markColor,
+},
+line: {
+   color: markColor,
+   stroke: markColor,
+   strokewidth: 5,
+},
+trail: {
+   color: markColor,
+   stroke: markColor,
+   strokeWidth: 0,
+   size: 1,
+},
+path: {
+   stroke: markColor,
+   strokeWidth: 0.5,
+},
+point: {
+   filled: true,
+},
+text: {
+   font: sourceFont,
+   color: markColor,
+   fontSize: 11,
+   align: "center",
+   fontWeight: 400,
+   size: 11,
+}, 
+bar: {
+    // "size": 40,
+    // "binSpacing": 15,
+    // "continuousBandSize": 30,
+    // "discreteBandSize": 30,
+    fill: markColor,
+    stroke: false,
+},
+arc: {fill: markColor},
+shape: {stroke: markColor},
+symbol: {fill: markColor, size: 30},
+};
+
+export default urbanInstituteTheme;

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -1,23 +1,23 @@
 import {Config} from './config';
 
-const markColor = "#1696d2";
-const axisColor = "#000000";
-const backgroundColor = "#FFFFFF";
-const font = "Lato";
-const labelFont = "Lato";
-const sourceFont = "Lato";
-const gridColor = "#DEDDDD";
+const markColor = '#1696d2';
+const axisColor = '#000000';
+const backgroundColor = '#FFFFFF';
+const font = 'Lato';
+const labelFont = 'Lato';
+const sourceFont = 'Lato';
+const gridColor = '#DEDDDD';
 const titleFontSize = 18;
 
 const colorSchemes = {
   'main-colors': ['#1696d2', '#d2d2d2', '#000000', '#fdbf11', '#ec008b', '#55b748', '#5c5859', '#db2b27'],
-  'shades-blue': ["#CFE8F3","#A2D4EC","#73BFE2","#46ABDB","#1696D2","#12719E","#0A4C6A","#062635"],
-  'shades-gray': ["#F5F5F5","#ECECEC","#E3E3E3","#DCDBDB","#D2D2D2","#9D9D9D","#696969","#353535"],
-  'shades-yellow': ["#FFF2CF","#FCE39E","#FDD870","#FCCB41","#FDBF11","#E88E2D","#CA5800","#843215"],
-  'shades-magenta': ["#F5CBDF","#EB99C2","#E46AA7","#E54096","#EC008B","#AF1F6B","#761548","#351123"],
-  'shades-green': ["#DCEDD9","#BCDEB4","#98CF90","#78C26D","#55B748","#408941","#2C5C2D","#1A2E19"],
-  'shades-black': ["#D5D5D4","#ADABAC","#848081","#5C5859","#332D2F","#262223","#1A1717","#0E0C0D"],
-  'shades-red': ["#F8D5D4","#F1AAA9","#E9807D","#E25552","#DB2B27","#A4201D","#6E1614","#370B0A"],
+  'shades-blue': ['#CFE8F3','#A2D4EC','#73BFE2','#46ABDB','#1696D2','#12719E','#0A4C6A','#062635'],
+  'shades-gray': ['#F5F5F5','#ECECEC','#E3E3E3','#DCDBDB','#D2D2D2','#9D9D9D','#696969','#353535'],
+  'shades-yellow': ['#FFF2CF','#FCE39E','#FDD870','#FCCB41','#FDBF11','#E88E2D','#CA5800','#843215'],
+  'shades-magenta': ['#F5CBDF','#EB99C2','#E46AA7','#E54096','#EC008B','#AF1F6B','#761548','#351123'],
+  'shades-green': ['#DCEDD9','#BCDEB4','#98CF90','#78C26D','#55B748','#408941','#2C5C2D','#1A2E19'],
+  'shades-black': ['#D5D5D4','#ADABAC','#848081','#5C5859','#332D2F','#262223','#1A1717','#0E0C0D'],
+  'shades-red': ['#F8D5D4','#F1AAA9','#E9807D','#E25552','#DB2B27','#A4201D','#6E1614','#370B0A'],
   'one-group': ['#1696d2', '#000000'],
   'two-groups-cat-1': ['#1696d2', '#000000'],
   'two-groups-cat-2': ['#1696d2', '#fdbf11'],
@@ -41,7 +41,7 @@ const urbanInstituteTheme: Config = {
   background: backgroundColor,
 
   title: {
-    anchor: "start",
+    anchor: 'start',
     fontSize: titleFontSize,
     font: font,
 },
@@ -86,12 +86,12 @@ legend: {
    titleFontSize: 12,
    titlePadding: 10,
    titleFont: font,
-   orient: "right",
+   orient: 'right',
    offset: 10,
 },
 
 view: {
-   stroke: "transparent",
+   stroke: 'transparent',
 },
 
 range: {
@@ -136,7 +136,7 @@ text: {
    font: sourceFont,
    color: markColor,
    fontSize: 11,
-   align: "center",
+   align: 'center',
    fontWeight: 400,
    size: 11,
 }, 

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -59,7 +59,6 @@ axisX: {
    titleFontSize: 12,
    titlePadding: 10,
    titleFont: font,
-   //title: " ",
 },
 
 axisY: {
@@ -84,11 +83,9 @@ legend: {
    labelFontSize: 12,
    labelFont: labelFont,
    symbolSize: 100,
-   // "symbolType": "square",
    titleFontSize: 12,
    titlePadding: 10,
    titleFont: font,
-   //title: " ",
    orient: "right",
    offset: 10,
 },

--- a/src/theme-urbaninstitute.ts
+++ b/src/theme-urbaninstitute.ts
@@ -34,7 +34,7 @@ const colorSchemes = {
   'six-groups-cat-1': ['#1696d2', '#ec008b', '#fdbf11', '#000000', '#d2d2d2', '#55b748'],
   'six-groups-cat-2': ['#1696d2', '#d2d2d2', '#ec008b', '#fdbf11', '#332d2f', '#0a4c6a'],
   'six-groups-seq': ['#cfe8f3', '#a2d4ec', '#73bfe2', '#46abdb', '#1696d2', '#12719e'],
-  'diverging': ['#ca5800', '#fdbf11', '#fdd870', '#fff2cf', '#cfe8f3', '#73bfe2', '#1696d2', '#0a4c6a']
+  'diverging-colors': ['#ca5800', '#fdbf11', '#fdd870', '#fff2cf', '#cfe8f3', '#73bfe2', '#1696d2', '#0a4c6a']
 };
 
 const urbanInstituteTheme: Config = {
@@ -58,10 +58,10 @@ const urbanInstituteTheme: Config = {
     tickSize: 5,
     titleFontSize: 12,
     titlePadding: 10,
-    titleFont: font,
+    titleFont: font
   },
 
- axisY: {
+  axisY: {
     domain: false,
     domainWidth: 1,
     grid: true,
@@ -76,10 +76,10 @@ const urbanInstituteTheme: Config = {
     titleFont: font,
     titleAngle: 0,
     titleY: -10,
-    titleX: 18,
+    titleX: 18
   },
 
- legend: {
+  legend: {
     labelFontSize: 12,
     labelFont: labelFont,
     symbolSize: 100,
@@ -87,70 +87,70 @@ const urbanInstituteTheme: Config = {
     titlePadding: 10,
     titleFont: font,
     orient: 'right',
-    offset: 10,
+    offset: 10
   },
 
- view: {
-    stroke: 'transparent',
+  view: {
+    stroke: 'transparent'
   },
 
- range: {
+  range: {
     category: colorSchemes['six-groups-cat-1'],
-    diverging: colorSchemes['diverging'],
-    heatmap: colorSchemes['diverging'],
+    diverging: colorSchemes['diverging-colors'],
+    heatmap: colorSchemes['diverging-colors'],
     ordinal: colorSchemes['six-groups-seq'],
-    ramp: colorSchemes['shades-blue'],
+    ramp: colorSchemes['shades-blue']
   },
 
- area: {
-    fill: markColor,
+  area: {
+    fill: markColor
   },
 
- rect: {
-    fill: markColor,
+  rect: {
+    fill: markColor
   },
 
- line: {
+  line: {
     color: markColor,
     stroke: markColor,
-    strokeWidth: 5,
+    strokeWidth: 5
   },
 
- trail: {
+  trail: {
     color: markColor,
     stroke: markColor,
     strokeWidth: 0,
-    size: 1,
+    size: 1
   },
 
- path: {
+  path: {
     stroke: markColor,
-    strokeWidth: 0.5,
+    strokeWidth: 0.5
   },
 
- point: {
-    filled: true,
+  point: {
+    filled: true
   },
 
- text: {
+  text: {
     font: sourceFont,
     color: markColor,
     fontSize: 11,
     align: 'center',
     fontWeight: 400,
-    size: 11,
-  }, 
-
- style: {
- bar: {
-    fill: markColor,
-    stroke: false,
-   }
+    size: 11
   },
 
-arc: {fill: markColor},
-shape: {stroke: markColor},
-symbol: {fill: markColor, size: 30}
+  style: {
+   bar: {
+     fill: markColor,
+     stroke: false,
+    }
+  },
+
+  arc: {fill: markColor},
+  shape: {stroke: markColor},
+  symbol: {fill: markColor, size: 30}
 };
 
 export default urbanInstituteTheme;


### PR DESCRIPTION
Hello! 
A while ago I wrote an article for Towards Data Science about using themes on `altair`  [here](https://towardsdatascience.com/consistently-beautiful-visualizations-with-altair-themes-c7f9f889602)
and @domoritz responded with an invitation to suggest any changes to the existing themes or add a new theme. 

I'm more than happy to add to the existing themes but to get the ball rolling I _translated_ the Urban Institute's theme I had used for my article to a format that would work here.

On top of adding the `.ts` file I have also added the references to it on the `src/index.ts`, `README.md` and `examples/index.html` files.

I have tested it locally using yarn but let me know if there's anything else that's missing or I should improve. I'm not a js dev so I could have missed something very obvious, if I did I'm more than happy to fix it asap. 

Thanks for the amazing tool you've created! 

***
The theme is based off of their data visualization styleguide <https://urbaninstitute.github.io/graphics-styleguide/>