### PR TITLE
add googlecharts theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ vega.themes.<b>urbaninstitute</b>
 
 Chart theme modeled after the Urban Institute. [Try it here](https://vega.github.io/vega-themes/?theme=urbaninstitute).
 
+<a name="googlecharts " href="#googlecharts">#</a>
+vega.themes.<b>googlecharts</b>
+[<>](https://github.com/vega/vega-themes/blob/master/src/theme-googlecharts.ts "Source")
+
+Chart theme modeled after Google Charts. [Try it here](https://vega.github.io/vega-themes/?theme=googlecharts).
+
+
 ## Instructions for Developers
 
 To view and test different themes, follow these steps:

--- a/examples/index.html
+++ b/examples/index.html
@@ -60,6 +60,7 @@
         <option value="fivethirtyeight">fivethirtyeight</option>
         <option value="latimes">latimes</option>
         <option value="urbaninstitute">urbaninstitute</option>
+        <option value="googlecharts">googlecharts</option>
       </select>
       &nbsp; Renderer:
       <select id="render">

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export {default as latimes} from './theme-latimes';
 export {default as quartz} from './theme-quartz';
 export {default as vox} from './theme-vox';
 export {default as urbaninstitute} from './theme-urbaninstitute';
+export {default as googlecharts} from './theme-googlecharts';
 export {version};

--- a/src/theme-googlecharts.ts
+++ b/src/theme-googlecharts.ts
@@ -1,6 +1,9 @@
 /**
  * Copyright 2020 Google LLC.
- * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
  */
 
 import {Config} from './config';

--- a/src/theme-googlecharts.ts
+++ b/src/theme-googlecharts.ts
@@ -19,21 +19,35 @@ const googlechartsTheme: Config = {
     bottom: 10,
     left: 10
   },
+  style: {
+    'guide-label': {
+      font: defaultFont
+    },
+    'guide-title': {
+      font: defaultFont
+    },
+    'group-title': {
+      font: defaultFont
+    }
+  },
   title: {
     font: defaultFont,
-    fontSize: 12,
+    fontSize: 14,
+    fontWeight: 'bold',
     dy: -3,
     anchor: 'start'
   },
   axis: {
-    labelFont: defaultFont,
+    titleFontSize: 12,
     labelFontSize: 12,
-    titleFont: defaultFont,
-    titleFontWeight: 200,
     gridColor: gridColor,
     tickColor: gridColor,
     domain: false,
     grid: true
+  },
+  legend: {
+    titleFontSize: 12,
+    labelFontSize: 12
   },
   range: {
     category: [

--- a/src/theme-googlecharts.ts
+++ b/src/theme-googlecharts.ts
@@ -1,0 +1,57 @@
+import {Config} from './config';
+
+const markColor = '#3366CC';
+const gridColor = '#ccc';
+const defaultFont = 'Arial, sans-serif';
+
+const googlechartsTheme: Config = {
+  arc: {fill: markColor},
+  area: {fill: markColor},
+  path: {stroke: markColor},
+  rect: {fill: markColor},
+  shape: {stroke: markColor},
+  symbol: {stroke: markColor},
+  circle: {fill: markColor},
+  background: '#fff',
+  padding: {
+    top: 10,
+    right: 10,
+    bottom: 10,
+    left: 10
+  },
+  title: {
+    font: defaultFont,
+    fontSize: 12,
+    dy: -3,
+    anchor: 'start'
+  },
+  axis: {
+    labelFont: defaultFont,
+    labelFontSize: 12,
+    titleFont: defaultFont,
+    titleFontWeight: 200,
+    gridColor: gridColor,
+    tickColor: gridColor,
+    domain: false,
+    grid: true
+  },
+  range: {
+    category: [
+      '#4285F4',
+      '#DB4437',
+      '#F4B400',
+      '#0F9D58',
+      '#AB47BC',
+      '#00ACC1',
+      '#FF7043',
+      '#9E9D24',
+      '#5C6BC0',
+      '#F06292',
+      '#00796B',
+      '#C2185B'
+    ],
+    heatmap: ['#c6dafc', '#5e97f6', '#2a56c6']
+  }
+};
+
+export default googlechartsTheme;

--- a/src/theme-googlecharts.ts
+++ b/src/theme-googlecharts.ts
@@ -21,13 +21,16 @@ const googlechartsTheme: Config = {
   },
   style: {
     'guide-label': {
-      font: defaultFont
+      font: defaultFont,
+      fontSize: 12
     },
     'guide-title': {
-      font: defaultFont
+      font: defaultFont,
+      fontSize: 12
     },
     'group-title': {
-      font: defaultFont
+      font: defaultFont,
+      fontSize: 12
     }
   },
   title: {
@@ -38,16 +41,10 @@ const googlechartsTheme: Config = {
     anchor: 'start'
   },
   axis: {
-    titleFontSize: 12,
-    labelFontSize: 12,
     gridColor: gridColor,
     tickColor: gridColor,
     domain: false,
     grid: true
-  },
-  legend: {
-    titleFontSize: 12,
-    labelFontSize: 12
   },
   range: {
     category: [

--- a/src/theme-googlecharts.ts
+++ b/src/theme-googlecharts.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2020 Google LLC.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {Config} from './config';
 
 const markColor = '#3366CC';


### PR DESCRIPTION
This is a theme loosely based on [Google Charts](https://developers.google.com/chart).

I tried to keep it simple and plan to update it as Vega themes become more sophisticated.

Here's a preview of what it looks like on the example page.

![Screen Shot 2020-02-06 at 12 08 07 PM](https://user-images.githubusercontent.com/156229/73975214-b5e55f00-48da-11ea-8f27-a964f0f25e83.png)

In development, I have my own version of the examples with a few more chart types.

These have slightly tweaked chart specs to adjust options that can't be set in the theme, like `tickCount`.

![Screen Shot 2020-02-06 at 12 08 35 PM](https://user-images.githubusercontent.com/156229/73975376-0ceb3400-48db-11ea-9de3-9e2bd603c0c7.png)
