### PR TITLE
fix: set light subtitle color for dark theme

### DIFF
--- a/src/theme-dark.ts
+++ b/src/theme-dark.ts
@@ -6,7 +6,10 @@ const medColor = '#888';
 const darkTheme: Config = {
   background: '#333',
 
-  title: {color: lightColor},
+  title: {
+      color: lightColor,
+      subtitleColor: lightColor
+  },
 
   style: {
     'guide-label': {


### PR DESCRIPTION
Currently the subtitle color remains black when switching to the dark theme, which means it is not possible to discern it against the dark background. This looks like the correct fix to me, but not sure how I would test it (if needed).