### PR TITLE
ci: use same release process as vega embed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,13 @@ jobs:
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 
+      - name: Build
+        run: yarn build
+
+      # don't use yarn run to avoid using yarnpkg registry
       - name: Create release
-        run: yarn run release
+        run: npm run release
         env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "copy:data": "rsync -r node_modules/vega-datasets/data/* examples/data",
     "copy:build": "rsync -r build/* examples/build",
     "deploy:gh": "yarn build && mkdir -p examples/build && rsync -r build/* examples/build && gh-pages -d examples",
-    "prepublishOnly": "yarn clean && yarn build",
     "preversion": "yarn lint",
     "serve": "browser-sync start -s -f build examples --serveStatic examples",
     "start": "yarn build && concurrently --kill-others -n Server,Rollup 'yarn serve' 'rollup -c -w'",
@@ -59,7 +58,7 @@
     "eslintbase": "beemo eslint .",
     "format": "yarn eslintbase --fix",
     "lint": "yarn eslintbase",
-    "release": "yarn prepublishOnly && yarn auto shipit"
+    "release": "auto shipit"
   },
   "devDependencies": {
     "@auto-it/conventional-commits": "^10.32.2",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.10.1--canary.325.ca4a56e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-themes@2.10.1--canary.325.ca4a56e.0
  # or 
  yarn add vega-themes@2.10.1--canary.325.ca4a56e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
