### PR TITLE
Color outline correctly in dark theme

### DIFF
--- a/src/theme-dark.ts
+++ b/src/theme-dark.ts
@@ -5,7 +5,11 @@ const medColor = '#888';
 
 const darkTheme: Config = {
   background: '#333',
-
+   
+  view: {
+    stroke: medColor,
+  },
+  
   title: {
     color: lightColor,
     subtitleColor: lightColor,


### PR DESCRIPTION
For the default light theme, the color of the chart outline is the same as the color of the gridlines:

![image](https://user-images.githubusercontent.com/4560057/195416031-55868c63-f51c-4fda-b318-2df9c0ae13fd.png)

But for dark charts it is instead the same as the axis line:

![image](https://user-images.githubusercontent.com/4560057/195416167-c518d9b5-8484-4a8f-81f2-f73f342cbe9c.png)

This PR sets it to be the same in dark mode as well