### PR TITLE
feat: add carbon themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,63 +33,88 @@ input specification must be re-parsed with a new theme.
 
 <a name="excel" href="#excel">#</a>
 vega.themes.<b>excel</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-excel.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-excel.ts "Source")
 
 Chart theme modeled after Microsoft Excel. [Try it here](https://vega.github.io/vega-themes/?theme=excel).
 
 <a name="ggplot2" href="#ggplot2">#</a>
 vega.themes.<b>ggplot2</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-ggplot2.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-ggplot2.ts "Source")
 
 Chart theme modeled after ggplot2. [Try it here](https://vega.github.io/vega-themes/?theme=ggplot2).
 
 <a name="quartz" href="#quartz">#</a>
 vega.themes.<b>quartz</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-quartz.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-quartz.ts "Source")
 
 Chart theme modeled after Quartz. [Try it here](https://vega.github.io/vega-themes/?theme=quartz).
 
 <a name="vox" href="#vox">#</a>
 vega.themes.<b>vox</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-vox.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-vox.ts "Source")
 
 Chart theme modeled after Vox. [Try it here](https://vega.github.io/vega-themes/?theme=vox).
 
 <a name="fivethirtyeight" href="#fivethirtyeight">#</a>
 vega.themes.<b>fivethirtyeight</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-fivethirtyeight.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-fivethirtyeight.ts "Source")
 
 Chart theme modeled after FiveThirtyEight. [Try it here](https://vega.github.io/vega-themes/?theme=fivethirtyeight).
 
 <a name="dark" href="#dark">#</a>
 vega.themes.<b>dark</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-dark.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-dark.ts "Source")
 
 A dark theme. [Try it here](https://vega.github.io/vega-themes/?theme=dark).
 
 <a name="latimes" href="#latimes">#</a>
 vega.themes.<b>latimes</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-latimes.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-latimes.ts "Source")
 
 Chart theme modeled after the Los Angeles Times. [Try it here](https://vega.github.io/vega-themes/?theme=latimes).
 
 <a name="urbaninstitute" href="#urbaninstitute">#</a>
 vega.themes.<b>urbaninstitute</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-urbaninstitute.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-urbaninstitute.ts "Source")
 
 Chart theme modeled after the Urban Institute. [Try it here](https://vega.github.io/vega-themes/?theme=urbaninstitute).
 
 <a name="googlecharts " href="#googlecharts">#</a>
 vega.themes.<b>googlecharts</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-googlecharts.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-googlecharts.ts "Source")
 
 Chart theme modeled after Google Charts. [Try it here](https://vega.github.io/vega-themes/?theme=googlecharts).
 
 <a name="powerbi " href="#powerbi">#</a>
 vega.themes.<b>powerbi</b>
-[<>](https://github.com/vega/vega-themes/blob/master/src/theme-powerbi.ts "Source")
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-powerbi.ts "Source")
 
 Chart theme modeled after Power BI Desktop default theme. [Try it here](https://vega.github.io/vega-themes/?theme=powerbi).
+
+<a name="carbonwhite " href="#carbonwhite">#</a>
+vega.themes.<b>carbonwhite</b>
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-carbonwhite.ts "Source")
+
+Chart theme modeled after IBM Carbon Charts - white theme. [Try it here](https://vega.github.io/vega-themes/?theme=carbonwhite).
+
+<a name="carbong10" href="#carbong10">#</a>
+vega.themes.<b>carbong10</b>
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-carbong10.ts "Source")
+
+Chart theme modeled after IBM Carbon Charts - grey 10 theme. This is the white theme with a slightly darker background. [Try it here](https://vega.github.io/vega-themes/?theme=carbong10).
+
+<a name="carbong90" href="#carbong90">#</a>
+vega.themes.<b>carbong90</b>
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-carbong90.ts "Source")
+
+Chart theme modeled after IBM Carbon Charts - grey 90 theme. [Try it here](https://vega.github.io/vega-themes/?theme=carbong90).
+
+<a name="carbong100" href="#carbong100">#</a>
+vega.themes.<b>carbong100</b>
+[<>](https://github.com/vega/vega-themes/blob/main/src/theme-carbong100.ts "Source")
+
+Chart theme modeled after IBM Carbon Charts - grey 100 theme. This is the grey 90 theme with a slightly darker background. [Try it here](https://vega.github.io/vega-themes/?theme=carbong100).
+
 
 ## Instructions for Developers
 

--- a/examples/diverging.vl.json
+++ b/examples/diverging.vl.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "description": "A dot plot showing each movie in the database, and the difference from the average movie rating. The display is sorted by year to visualize everything in sequential order. The graph is for all Movies before 2019.",
+    "data": {
+      "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "transform": [
+      {"filter": "datum['IMDB Rating'] != null"},
+      {"filter": {"timeUnit": "year", "field": "Release Date", "range": [null, 2019]}},
+      {
+        "joinaggregate": [{
+          "op": "mean",
+          "field": "IMDB Rating",
+          "as": "AverageRating"
+        }]
+      },
+      {
+        "calculate": "datum['IMDB Rating'] - datum.AverageRating",
+        "as": "RatingDelta"
+      }
+    ],
+    "mark": "point",
+    "encoding": {
+      "x": {
+        "field": "Release Date",
+        "type": "temporal"
+      },
+      "y": {
+        "field": "RatingDelta",
+        "type": "quantitative",
+        "title": "Rating Delta"
+      },
+      "color": {
+        "field": "RatingDelta",
+        "type": "quantitative",
+        "scale": {"domainMid": 0},
+        "title": "Rating Delta"
+      }
+    }
+  }

--- a/examples/index.html
+++ b/examples/index.html
@@ -62,6 +62,10 @@
         <option value="urbaninstitute">urbaninstitute</option>
         <option value="googlecharts">googlecharts</option>
         <option value="powerbi">powerbi</option>
+        <option value="carbonwhite">carbonwhite</option>
+        <option value="carbong10">carbong10</option>
+        <option value="carbong90">carbong90</option>
+        <option value="carbong100">carbong100</option>
       </select>
       &nbsp; Renderer:
       <select id="render">
@@ -80,6 +84,7 @@
         "area.vl.json",
         "heatmap.vl.json",
         "ramp.vl.json",
+        "diverging.vl.json",
       ];
       var specs = [];
 

--- a/src/carbongen.ts
+++ b/src/carbongen.ts
@@ -1,0 +1,145 @@
+import {Config} from './config';
+
+const defaultFont = 'IBM Plex Sans,system-ui,-apple-system,BlinkMacSystemFont,".sfnstext-regular",sans-serif';
+const fontWeight = 400;
+
+const darkCategories = [
+    "#8a3ffc",
+    "#33b1ff",
+    "#007d79",
+    "#ff7eb6",
+    "#fa4d56",
+    "#fff1f1",
+    "#6fdc8c",
+    "#4589ff",
+    "#d12771",
+    "#d2a106",
+    "#08bdba",
+    "#bae6ff",
+    "#ba4e00",
+    "#d4bbff"
+];
+
+const lightCategories = [
+    "#6929c4",
+    "#1192e8",
+    "#005d5d",
+    "#9f1853",
+    "#fa4d56",
+    "#570408",
+    "#198038",
+    "#002d9c",
+    "#ee538b",
+    "#b28600",
+    "#009d9a",
+    "#012749",
+    "#8a3800",
+    "#a56eff"
+]
+
+const genCarbonConfig = (
+    {
+        type,
+        background
+    }: {
+        type: "light" | "dark",
+        background: string,
+    }
+) => {
+
+    const viewbg = type === "dark" ? "#161616" : "#ffffff";
+    const textColor = type === "dark" ? "#f4f4f4" : "#161616";
+    const category = type === "dark" ? darkCategories : lightCategories;
+    const markColor = type === "dark" ? "#d4bbff" : "#6929c4";
+
+    return ({
+        background,
+
+
+        arc: { fill: markColor },
+        area: { fill: markColor },
+        path: { stroke: markColor },
+        rect: { fill: markColor },
+        shape: { stroke: markColor },
+        symbol: { stroke: markColor },
+        circle: { fill: markColor },
+
+        view: {
+            fill: viewbg,
+            stroke: viewbg
+        },
+
+        group: {
+            fill: viewbg
+        },
+
+        title: {
+            color: textColor,
+            anchor: "start",
+            dy: -15,
+            fontSize: 16,
+            font: defaultFont,
+            fontWeight: 600
+        },
+
+        axis: {
+            labelColor: textColor,
+            labelFontSize: 12,
+            grid: true,
+            gridColor: "#525252",
+            titleColor: textColor,
+            labelAngle: 0
+        },
+
+
+        style: {
+            'guide-label': {
+                font: defaultFont,
+                fill: textColor,
+                fontWeight: fontWeight
+            },
+            'guide-title': {
+                font: defaultFont,
+                fill: textColor,
+                fontWeight: fontWeight
+            },
+        },
+
+
+        range: {
+            category,
+            diverging: [
+                '#750e13',
+                '#a2191f',
+                '#da1e28',
+                '#fa4d56',
+                '#ff8389',
+                '#ffb3b8',
+                '#ffd7d9',
+                '#fff1f1',
+                '#e5f6ff',
+                '#bae6ff',
+                '#82cfff',
+                '#33b1ff',
+                '#1192e8',
+                '#0072c3',
+                '#00539a',
+                '#003a6d'],
+            heatmap: [
+                '#f6f2ff',
+                '#e8daff',
+                '#d4bbff',
+                '#be95ff',
+                '#a56eff',
+                '#8a3ffc',
+                '#6929c4',
+                '#491d8b',
+                '#31135e',
+                '#1c0f30'],
+
+        }
+    }
+    ) as Config
+}
+
+export default genCarbonConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,8 @@ export {default as vox} from './theme-vox';
 export {default as urbaninstitute} from './theme-urbaninstitute';
 export {default as googlecharts} from './theme-googlecharts';
 export {default as powerbi} from './theme-powerbi';
+export {default as carbonwhite} from './theme-carbonwhite';
+export {default as carbong10} from './theme-carbong10';
+export {default as carbong90} from './theme-carbong90';
+export {default as carbong100} from './theme-carbong100';
 export {version};

--- a/src/theme-carbong10.ts
+++ b/src/theme-carbong10.ts
@@ -1,0 +1,8 @@
+import genCarbonConfig from './carbongen';
+
+const carbong10 = genCarbonConfig({
+  type: "light",
+  background: "#f4f4f4"
+});
+
+export default carbong10;

--- a/src/theme-carbong100.ts
+++ b/src/theme-carbong100.ts
@@ -1,0 +1,8 @@
+import genCarbonConfig from './carbongen';
+
+const carbong100 = genCarbonConfig({
+  type: "dark",
+  background: "#161616"
+});
+
+export default carbong100;

--- a/src/theme-carbong90.ts
+++ b/src/theme-carbong90.ts
@@ -1,0 +1,8 @@
+import genCarbonConfig from './carbongen';
+
+const carbong90 = genCarbonConfig({
+  type: "dark",
+  background: "#262626"
+});
+
+export default carbong90;

--- a/src/theme-carbonwhite.ts
+++ b/src/theme-carbonwhite.ts
@@ -1,0 +1,8 @@
+import genCarbonConfig from './carbongen';
+
+const carbonwhite = genCarbonConfig({
+  type: "light",
+  background: "#ffffff"
+});
+
+export default carbonwhite;


### PR DESCRIPTION

Hello! Thank you for the time in reviewing the PR. I'm happy to make any changes you'd like, just excited to contribute in a small way. I'm a big fan of vega. PR is for this issue:
https://github.com/vega/vega-themes/issues/478


### Changes:
1) Update the links in readme to point to main branch instead of old master branch (Power BI link for example was broken).

2) Add a new chart to the Vega Theme Test page to help test diverging color scales. The chart spec taken from this vega lite example:
https://vega.github.io/vega-lite/examples/joinaggregate_residual_graph.html
![image](https://github.com/vega/vega-themes/assets/3809398/2da18d93-0651-48fc-9021-cc2fb11dc822)

3) Add themes based on the IBM Carbon charts specification. One theme for each of Carbon white, g10, g90 and g100. The two two lighter themes and two darker themes appear to be the same except for a background color specification.
https://carbondesignsystem.com/data-visualization/getting-started/
![image](https://github.com/vega/vega-themes/assets/3809398/424da7fb-33d9-420c-a09d-f6106bb0bc8f)

Thanks again!


